### PR TITLE
View members fix

### DIFF
--- a/src/main/java/dev/tolana/projectcalculationtool/controller/DepartmentController.java
+++ b/src/main/java/dev/tolana/projectcalculationtool/controller/DepartmentController.java
@@ -34,17 +34,19 @@ public class DepartmentController {
     }
 
     @GetMapping("{deptId}/members")
-    public String organisationMembersView(@PathVariable("deptId") long departmentId, Model model){
+    public String organisationMembersView(@PathVariable("orgId") long orgId,
+            @PathVariable("deptId") long departmentId, Model model){
         //TODO exclude owner of department from results
         EntityViewDto department = departmentService.getDepartment(departmentId);
         model.addAttribute("department", department);
 
-        EntityViewDto organisation = departmentService.getParent(department.parentId());
+        EntityViewDto organisation = departmentService.getParent(orgId);
         model.addAttribute("organisation", organisation);
 
         List<UserEntityRoleDto> users = departmentService.getUsersFromOrganisationId(
                             organisation.id(),departmentId);
-        model.addAttribute("orgUsers",users);
+
+        model.addAttribute("deptUsers",users);
 
         return "department/viewMembers";
     }

--- a/src/main/java/dev/tolana/projectcalculationtool/dto/UserEntityRoleDto.java
+++ b/src/main/java/dev/tolana/projectcalculationtool/dto/UserEntityRoleDto.java
@@ -6,7 +6,13 @@ public record UserEntityRoleDto(String username,
                                 long projectId,
                                 long teamId,
                                 long departmentId,
-                                long organizationId) {
+                                long organizationId)
+implements Comparable<UserEntityRoleDto>
+{
+    @Override
+    public int compareTo(UserEntityRoleDto userEntityRoleDto){
+        return CharSequence.compare(this.username,userEntityRoleDto.username);
+    }
 }
 
 

--- a/src/main/java/dev/tolana/projectcalculationtool/repository/impl/JdbcDepartmentRepository.java
+++ b/src/main/java/dev/tolana/projectcalculationtool/repository/impl/JdbcDepartmentRepository.java
@@ -255,7 +255,7 @@ public class JdbcDepartmentRepository implements DepartmentRepository {
                     SELECT DISTINCT username, role_id, task_id, project_id, team_id, department_id, organisation_id
                     FROM user_entity_role
                     WHERE organisation_id = ? OR department_id = ?
-                    ORDER BY username;
+                    ORDER BY role_id DESC;
                     """;
 
             PreparedStatement pstmt = connection.prepareStatement(getAllUsersFromOrganisation);
@@ -286,38 +286,7 @@ public class JdbcDepartmentRepository implements DepartmentRepository {
         }
 
 
-        List<UserEntityRoleDto> cleanedUsers = getCleanUserEntityRoleDtos(users);
-
-        return cleanedUsers;
-    }
-
-    private static List<UserEntityRoleDto> getCleanUserEntityRoleDtos(List<UserEntityRoleDto> users) {
-        //takes the list of user entities sorted by Username and checks if there's a duplicate
-        //if there is a duplicate, the first one will always have 0 as deptId, and so it is set
-        //to the second one's deptId, which is then used for operations in the html page
-        List<UserEntityRoleDto> cleanedUsers = new ArrayList<>();
-        for (int i = 0; i < users.size(); i++) {
-            if(i+1 != users.size()){ //avoids out of bounds
-                if (users.get(i+1).username().equals(users.get(i).username())){
-                    //adds user with the deptID of the duplicate that comes after it
-                    cleanedUsers.add(new UserEntityRoleDto(users.get(i).username(),
-                            users.get(i).roleId(), users.get(i).taskId(), users.get(i).projectId(),
-                            users.get(i).teamId(), users.get(i+1).departmentId(),
-                            users.get(i).organizationId()));
-                }else if(i != 0){ //avoids out of bounds
-                    if (!users.get(i-1).username().equals(users.get(i).username())){
-                        //checks that user isn't a duplicate of the previous user
-                        //without this, only users with duplicates, and the last index place will be added
-                        cleanedUsers.add(users.get(i));
-                    }
-                }
-            }else if(i != 0){
-                if(!users.get(i-1).username().equals(users.get(i).username())) {
-                    cleanedUsers.add(users.get(i));
-                }
-            }
-        }
-        return cleanedUsers;
+        return users;
     }
 
     @Override

--- a/src/main/java/dev/tolana/projectcalculationtool/repository/impl/JdbcProjectRepository.java
+++ b/src/main/java/dev/tolana/projectcalculationtool/repository/impl/JdbcProjectRepository.java
@@ -579,7 +579,7 @@ public class JdbcProjectRepository implements ProjectRepository {
                     SELECT DISTINCT username, role_id, task_id, project_id, team_id, department_id, organisation_id
                     FROM user_entity_role
                     WHERE team_id = ? OR project_id = ?
-                    ORDER BY username;
+                    ORDER BY role_id DESC;
                     """;
 
             PreparedStatement pstmt = connection.prepareStatement(getAllUsersFromTeam);
@@ -609,34 +609,6 @@ public class JdbcProjectRepository implements ProjectRepository {
             sqlException.printStackTrace();
         }
 
-
-        List<UserEntityRoleDto> cleanedUsers = getCleanUserEntityRoleDtos(users);
-
-        return cleanedUsers;
-    }
-
-
-    private static List<UserEntityRoleDto> getCleanUserEntityRoleDtos(List<UserEntityRoleDto> users) {
-        List<UserEntityRoleDto> cleanedUsers = new ArrayList<>();
-        for (int i = 0; i < users.size(); i++) {
-            if(i+1 != users.size()){ //avoids out of bounds
-                if (users.get(i+1).username().equals(users.get(i).username())){
-                    //adds user with the teamId of the duplicate that comes after it
-                    cleanedUsers.add(new UserEntityRoleDto(users.get(i).username(),
-                            users.get(i).roleId(), users.get(i).taskId(), users.get(i+1).projectId(),
-                            users.get(i).teamId(), users.get(i).departmentId(),
-                            users.get(i).organizationId()));
-                }else if(i != 0){ //avoids out of bounds
-                    if (!users.get(i-1).username().equals(users.get(i).username())){
-                        cleanedUsers.add(users.get(i));
-                    }
-                }
-            }else if(i != 0){
-                if(!users.get(i-1).username().equals(users.get(i).username())) {
-                    cleanedUsers.add(users.get(i));
-                }
-            }
-        }
-        return cleanedUsers;
+        return users;
     }
 }

--- a/src/main/java/dev/tolana/projectcalculationtool/repository/impl/JdbcTeamRepository.java
+++ b/src/main/java/dev/tolana/projectcalculationtool/repository/impl/JdbcTeamRepository.java
@@ -299,7 +299,7 @@ public class JdbcTeamRepository implements TeamRepository {
                     SELECT DISTINCT username, role_id, task_id, project_id, team_id, department_id, organisation_id
                     FROM user_entity_role
                     WHERE department_id = ? OR team_id = ?
-                    ORDER BY username;
+                    ORDER BY role_id DESC;
                     """;
 
             PreparedStatement pstmt = connection.prepareStatement(getAllUsersFromDepartment);
@@ -329,35 +329,7 @@ public class JdbcTeamRepository implements TeamRepository {
             sqlException.printStackTrace();
         }
 
-
-        List<UserEntityRoleDto> cleanedUsers = getCleanUserEntityRoleDtos(users);
-
-        return cleanedUsers;
-    }
-
-
-    private static List<UserEntityRoleDto> getCleanUserEntityRoleDtos(List<UserEntityRoleDto> users) {
-        List<UserEntityRoleDto> cleanedUsers = new ArrayList<>();
-        for (int i = 0; i < users.size(); i++) {
-            if(i+1 != users.size()){ //avoids out of bounds
-                if (users.get(i+1).username().equals(users.get(i).username())){
-                    //adds user with the teamId of the duplicate that comes after it
-                    cleanedUsers.add(new UserEntityRoleDto(users.get(i).username(),
-                            users.get(i).roleId(), users.get(i).taskId(), users.get(i).projectId(),
-                            users.get(i+1).teamId(), users.get(i).departmentId(),
-                            users.get(i).organizationId()));
-                }else if(i != 0){ //avoids out of bounds
-                    if (!users.get(i-1).username().equals(users.get(i).username())){
-                        cleanedUsers.add(users.get(i));
-                    }
-                }
-            }else if(i != 0){
-                if(!users.get(i-1).username().equals(users.get(i).username())) {
-                    cleanedUsers.add(users.get(i));
-                }
-            }
-        }
-        return cleanedUsers;
+        return users;
     }
 
     @Override

--- a/src/main/java/dev/tolana/projectcalculationtool/service/DepartmentService.java
+++ b/src/main/java/dev/tolana/projectcalculationtool/service/DepartmentService.java
@@ -8,6 +8,8 @@ import org.springframework.security.access.prepost.PostFilter;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Service;
 
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 @Service
@@ -67,7 +69,29 @@ public class DepartmentService {
     }
 
     public List<UserEntityRoleDto> getUsersFromOrganisationId(long organisationId,long departmentId){
-        return jdbcDepartmentRepository.getUsersFromParentIdAndEntityId(organisationId,departmentId);
+        List<UserEntityRoleDto> scrubbedUsers = new ArrayList<>();
+
+        List<UserEntityRoleDto> users = jdbcDepartmentRepository.getUsersFromParentIdAndEntityId(
+                                organisationId,departmentId);
+
+        for (UserEntityRoleDto user: users) {
+            boolean exists = false;
+            if (!scrubbedUsers.isEmpty()){
+                for (UserEntityRoleDto scrub: scrubbedUsers) {
+                    if (user.username().equals(scrub.username())){
+                        exists = true;
+                    }
+                }
+                if (!exists){
+                    scrubbedUsers.add(user);
+                }
+            }else{
+                scrubbedUsers.add(user);
+            }
+        }
+
+        Collections.sort(scrubbedUsers);
+        return scrubbedUsers;
     }
 
     public UserEntityRoleDto getUserFromOrganisationId(String username, long orgId){

--- a/src/main/java/dev/tolana/projectcalculationtool/service/ProjectService.java
+++ b/src/main/java/dev/tolana/projectcalculationtool/service/ProjectService.java
@@ -12,6 +12,7 @@ import dev.tolana.projectcalculationtool.repository.ProjectRepository;
 import org.springframework.stereotype.Service;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 @Service
@@ -95,7 +96,29 @@ public class ProjectService {
     }
 
     public List<UserEntityRoleDto> getUsersFromTeamId(long teamId,long projectId){
-        return projectRepository.getUsersFromParentIdAndEntityId(teamId,projectId);
+        List<UserEntityRoleDto> scrubbedUsers = new ArrayList<>();
+
+        List<UserEntityRoleDto> users = projectRepository.getUsersFromParentIdAndEntityId(
+                teamId,projectId);
+
+        for (UserEntityRoleDto user: users) {
+            boolean exists = false;
+            if (!scrubbedUsers.isEmpty()){
+                for (UserEntityRoleDto scrub: scrubbedUsers) {
+                    if (user.username().equals(scrub.username())){
+                        exists = true;
+                    }
+                }
+                if (!exists){
+                    scrubbedUsers.add(user);
+                }
+            }else{
+                scrubbedUsers.add(user);
+            }
+        }
+
+        Collections.sort(scrubbedUsers);
+        return scrubbedUsers;
     }
 
     public UserEntityRoleDto getUserFromTeamId(String username, long teamId){

--- a/src/main/java/dev/tolana/projectcalculationtool/service/TeamService.java
+++ b/src/main/java/dev/tolana/projectcalculationtool/service/TeamService.java
@@ -7,6 +7,8 @@ import dev.tolana.projectcalculationtool.model.Entity;
 import dev.tolana.projectcalculationtool.repository.TeamRepository;
 import org.springframework.stereotype.Service;
 
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 @Service
@@ -58,7 +60,29 @@ public class TeamService {
 
 
     public List<UserEntityRoleDto> getUsersFromDepartmentId(long departmentId,long teamId){
-        return teamRepository.getUsersFromParentIdAndEntityId(departmentId,teamId);
+        List<UserEntityRoleDto> scrubbedUsers = new ArrayList<>();
+
+        List<UserEntityRoleDto> users = teamRepository.getUsersFromParentIdAndEntityId(
+                departmentId,teamId);
+
+        for (UserEntityRoleDto user: users) {
+            boolean exists = false;
+            if (!scrubbedUsers.isEmpty()){
+                for (UserEntityRoleDto scrub: scrubbedUsers) {
+                    if (user.username().equals(scrub.username())){
+                        exists = true;
+                    }
+                }
+                if (!exists){
+                    scrubbedUsers.add(user);
+                }
+            }else{
+                scrubbedUsers.add(user);
+            }
+        }
+
+        Collections.sort(scrubbedUsers);
+        return scrubbedUsers;
     }
 
     public UserEntityRoleDto getUserFromDepartmentId(String username, long deptId){

--- a/src/main/resources/templates/department/viewMembers.html
+++ b/src/main/resources/templates/department/viewMembers.html
@@ -17,27 +17,28 @@
                     <h1 th:text="${'Brugere i afdeling '+ department.name}"></h1>
                     <table class="table rounded align-middle">
                         <tbody>
-                        <tr th:each="user : ${orgUsers}">
+                        <tr th:each="user : ${deptUsers}">
                             <td th:text="${user.username}"></td>
                             <td>
                                 <div class="d-flex d-inline">
-
-                                    <!--TODO
-                                        add authorisation check
-                                    -->
 
                                     <div class="d-flex d-inline" th:if="${user.departmentId == 0}">
                                         <form th:action="@{members/assign/{username} (username = ${user.username})}" method="post">
                                             <button class="btn btn-success fw-bold">Invitér</button>
                                         </form>
                                     </div>
-                                    <div class="d-flex d-inline" th:if="${user.departmentId == department.id}">
-                                        <form th:action="@{members/promote/{username} (username = ${user.username})}" method="post">
+                                    <div class="d-flex d-inline" th:if="${user.departmentId == department.id}"
+                                        th:unless="${user.roleId == 5}">
+                                        <form th:unless="${user.roleId == 6}" th:action="@{members/promote/{username} (username = ${user.username})}" method="post">
                                             <button class="btn btn-warning btn-sm fw-bold" type="submit">Tildel Admin</button>
                                         </form>
                                         <form th:action="@{members/kick/{username} (username = ${user.username})}" method="post">
                                             <button class="btn btn-danger btn-sm fw-bold" type="submit">Fjern</button>
                                         </form>
+                                    </div>
+                                    <div>
+                                        <button th:if="${user.roleId == 5}" class="btn btn-success fw-bold"
+                                                type="submit">Owner</button>
                                     </div>
                                 </div>
                             </td>
@@ -48,7 +49,7 @@
 
                     <div class="d-flex">
                         <div class="d-inline">
-                            <a th:href="@{/organisation/{orgId}/department/{deptId} (orgId = ${department.parentId},
+                            <a th:href="@{/organisation/{orgId}/department/{deptId} (orgId = ${organisation.id},
                             deptId = ${department.id})}" class="btn btn-warning fw-bold">Gå tilbage</a>
                         </div>
                     </div>

--- a/src/main/resources/templates/organisation/viewMembers.html
+++ b/src/main/resources/templates/organisation/viewMembers.html
@@ -14,7 +14,7 @@
             <div th:replace="~{fragments/alerts :: alerts}"></div>
             <main class="d-flex justify-content-center text-center bg-secondary-subtle py-3 px-5 rounded shadow">
                 <div class="" style="width: 800px">
-                    <h1 th:text="${'Brugere i afdeling '+ organisation.name}"></h1>
+                    <h1 th:text="${'Brugere i organisation '+ organisation.name}"></h1>
                     <table class="table rounded align-middle">
                         <tbody>
                         <tr th:each="user : ${users}">
@@ -22,16 +22,16 @@
                             <td>
                                 <div class="d-flex d-inline">
 
-                                        <!--TODO
-                                            users has authorisation
-                                        -->
-
-                                    <form th:action="@{members/promote/{username} (username = ${user.username})}" method="post">
+                                    <form th:unless="${user.roleId == 1 || user.roleId == 2}" th:action=
+                                            "@{members/promote/{username} (username = ${user.username})}" method="post">
                                         <button class="btn btn-warning btn-sm fw-bold" type="submit">Tildel Admin</button>
                                     </form>
-                                    <form th:action="@{members/kick/{username} (username = ${user.username})}" method="post">
+                                    <form th:unless="${user.roleId == 1}" th:action="@{members/kick/{username}
+                                    (username = ${user.username})}" method="post">
                                         <button class="btn btn-danger btn-sm fw-bold" type="submit">Fjern</button>
                                     </form>
+                                    <button th:if="${user.roleId == 1}" class="btn btn-success fw-bold"
+                                            type="submit">Owner</button>
                                 </div>
                             </td>
                         </tr>

--- a/src/main/resources/templates/project/viewMembers.html
+++ b/src/main/resources/templates/project/viewMembers.html
@@ -22,22 +22,23 @@
                             <td>
                                 <div class="d-flex d-inline">
 
-                                    <!--TODO
-                                        add authorisation check
-                                    -->
-
                                     <div class="d-flex d-inline" th:if="${user.projectId == 0}">
                                         <form th:action="@{members/assign/{username} (username = ${user.username})}" method="post">
                                             <button class="btn btn-success fw-bold">Invitér</button>
                                         </form>
                                     </div>
-                                    <div class="d-flex d-inline" th:if="${user.projectId == project.id}">
-                                        <form th:action="@{members/promote/{username} (username = ${user.username})}" method="post">
+                                    <div class="d-flex d-inline" th:if="${user.projectId == project.id}"
+                                         th:unless="${user.roleId == 13}">
+                                        <form th:unless="${user.roleId == 14}" th:action="@{members/promote/{username} (username = ${user.username})}" method="post">
                                             <button class="btn btn-warning btn-sm fw-bold" type="submit">Tildel Admin</button>
                                         </form>
                                         <form th:action="@{members/kick/{username} (username = ${user.username})}" method="post">
                                             <button class="btn btn-danger btn-sm fw-bold" type="submit">Fjern</button>
                                         </form>
+                                    </div>
+                                    <div>
+                                        <button th:if="${user.roleId == 13}" class="btn btn-success fw-bold"
+                                                type="submit">Owner</button>
                                     </div>
                                 </div>
                             </td>

--- a/src/main/resources/templates/team/viewMembers.html
+++ b/src/main/resources/templates/team/viewMembers.html
@@ -22,22 +22,23 @@
                             <td>
                                 <div class="d-flex d-inline">
 
-                                    <!--TODO
-                                        add authorisation check
-                                    -->
-
                                     <div class="d-flex d-inline" th:if="${user.teamId == 0}">
                                         <form th:action="@{members/assign/{username} (username = ${user.username})}" method="post">
                                             <button class="btn btn-success fw-bold">Invitér</button>
                                         </form>
                                     </div>
-                                    <div class="d-flex d-inline" th:if="${user.teamId == team.id}">
-                                        <form th:action="@{members/promote/{username} (username = ${user.username})}" method="post">
+                                    <div class="d-flex d-inline" th:if="${user.teamId == team.id}"
+                                         th:unless="${user.roleId == 9}">
+                                        <form th:unless="${user.roleId == 10}" th:action="@{members/promote/{username} (username = ${user.username})}" method="post">
                                             <button class="btn btn-warning btn-sm fw-bold" type="submit">Tildel Admin</button>
                                         </form>
                                         <form th:action="@{members/kick/{username} (username = ${user.username})}" method="post">
                                             <button class="btn btn-danger btn-sm fw-bold" type="submit">Fjern</button>
                                         </form>
+                                    </div>
+                                    <div>
+                                        <button th:if="${user.roleId == 9}" class="btn btn-success fw-bold"
+                                                type="submit">Owner</button>
                                     </div>
                                 </div>
                             </td>


### PR DESCRIPTION
Har genlavet den algoritme der scrubber users til viewMembers metoderne, således at den er kortere og nemmere at forstå. Syntes selv det er en ret fed løsning som ikke kræver noget "jank", som ofte er tilfældet men den type operation vi vil lave på vores user data.

Har også gjort html templates for viewMembers mere flexible ved at tjekke både deres entity (department, team, project) ids og role ids. Role Id tjekkene er dog hardcodet værdier, men det kan refaktorers til at bruge ENUM.